### PR TITLE
feat: add skiprows and state filter to HTML generator

### DIFF
--- a/HTML_weekfollowup_generator.py
+++ b/HTML_weekfollowup_generator.py
@@ -13,7 +13,9 @@ def generate_suivi_html(
     tri_priorite_ascendant: bool = True,
     page_length: int = 25,
     trier_autres_alpha: bool = False,
-    nom_col_priorite_affiche: str = "Priorité"
+    nom_col_priorite_affiche: str = "Priorité",
+    skiprows: int = 10,
+    etats_conserves=None,
 ) -> str:
     """
     Génère un HTML unique listant les actions par ingénieur.
@@ -23,7 +25,9 @@ def generate_suivi_html(
     - `tri_priorite_ascendant`: True => 1->10 ; False => 10->1
     - `page_length`: nombre de lignes affichées par page (DataTables).
     - `nom_col_priorite_affiche`: nom de la colonne "Priorité" à afficher dans le tableau (si votre Excel varie).
-    
+    - `skiprows`: nombre de lignes ignorées au début de la feuille Excel.
+    - `etats_conserves`: liste des états conservés dans la colonne "Etat".
+
     Retourne le chemin du fichier HTML généré.
     """
     if ordre_voulu is None:
@@ -49,8 +53,10 @@ def generate_suivi_html(
     os.makedirs(os.path.dirname(sortie_html) or ".", exist_ok=True)
 
     # --- Lecture & préparation ---
-    df = pd.read_excel(fichier_excel, sheet_name=nom_feuille, skiprows=10)
-    df = df[df["Etat"].isin(["En cours", "Non démarrée"])].copy()
+    if etats_conserves is None:
+        etats_conserves = ["En cours", "Non démarrée"]
+    df = pd.read_excel(fichier_excel, sheet_name=nom_feuille, skiprows=skiprows)
+    df = df[df["Etat"].isin(etats_conserves)].copy()
     df = df.fillna("")
 
     # colonne de priorité (numérique) pour tri
@@ -211,6 +217,8 @@ if __name__ == "__main__":
         tri_priorite_ascendant=True,   # 1 -> 10
         page_length=25,
         trier_autres_alpha=False,      # mets True si tu veux les autres triés A→Z
-        nom_col_priorite_affiche="Priorité"
+        nom_col_priorite_affiche="Priorité",
+        skiprows=10,
+        etats_conserves=["En cours", "Non démarrée"],
     )
     print(f"✅ Fichier généré : {path}")


### PR DESCRIPTION
## Summary
- add `skiprows` and `etats_conserves` parameters to `generate_suivi_html`
- filter states via `etats_conserves` and use `skiprows` in Excel parsing
- document new arguments and showcase usage in example

## Testing
- `python -m py_compile HTML_weekfollowup_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfd9d8d48083229a7d2ed78501b020