### PR TITLE
Use Jinja2 template for HTML generation

### DIFF
--- a/HTML_weekfollowup_generator.py
+++ b/HTML_weekfollowup_generator.py
@@ -2,6 +2,7 @@ import os
 from datetime import date
 import re
 import pandas as pd
+from jinja2 import Environment, FileSystemLoader
 
 def generate_suivi_html(
     fichier_excel: str,
@@ -66,128 +67,53 @@ def generate_suivi_html(
         autres = sorted(autres)
     ingenieurs = [n for n in ordre_voulu if n in present] + autres
 
-    # --- HTML head ---
+    # --- Préparation des données pour le template ---
     order_dir = 'asc' if tri_priorite_ascendant else 'desc'
-    html = f"""<!DOCTYPE html>
-<html lang="fr">
-<head>
-<meta charset="utf-8">
-<title>Suivi des actions – {today}</title>
-<link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css"/>
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
-<style>
-  body {{ font-family: Arial, sans-serif; margin:20px; }}
-  h1, h2 {{ font-family: Arial, sans-serif; }}
-  .toc ul {{
-    display: flex; flex-wrap: wrap; gap: 8px;
-    padding: 0; margin: 0 0 30px 0;
-  }}
-  .toc li {{ list-style: none; }}
-  .toc a {{
-    display: block;
-    padding: 6px 12px;
-    background: #f2f2f2;
-    border-radius: 20px;
-    text-decoration: none;
-    color: #0066cc;
-    transition: background 0.2s;
-  }}
-  .toc a:hover {{ background: #ddeeff; }}
-  table {{ table-layout: fixed; width:100%; border-collapse: collapse; margin-bottom:40px; }}
-  th, td {{ padding:6px; border:1px solid #ddd; word-wrap: break-word; }}
-  th {{ background:#e6e6e6; font-size:14px; text-align:left; }}
-  td {{ font-size:12px; text-align:left; white-space: pre-wrap; }}
-  .en-conge {{ color:#a00; font-style: italic; margin: 6px 0 16px 0; }}
-</style>
-<script>
-$(document).ready(function() {{
-    $('table.display').each(function() {{
-      $(this).DataTable({{
-        paging:      true,
-        pageLength:  {page_length},
-        ordering:    true,
-        order:       [[3, '{order_dir}']],      // tri sur la colonne Priorité
-        columnDefs:  [{{ targets: 3, type: 'num' }}],
-        fixedHeader: true,
-        scrollX:     true,
-        language:    {{ url: 'https://cdn.datatables.net/plug-ins/1.13.4/i18n/fr-FR.json' }}
-      }});
-    }});
-}});
-</script>
-</head>
-<body>
-<h1>Suivi des actions – {today}</h1>
-
-<nav class="toc">
-  <ul>
-"""
-
-    # --- Sommaire
-    for nom in ingenieurs:
-        anchor = nom.replace(" ", "_")
-        html += f"    <li><a href='#{anchor}'>{nom}</a></li>\n"
-
-    html += """  </ul>
-</nav>
-
-<p><strong>Conventions de lecture du tableau :</strong></p>
-<ul>
-  <li><strong>Actions “Machine”</strong> : Toute action de calcul machine dont les données sont prêtes doit être priorisée, car il s’agit de temps machine et non de temps humain.</li>
-</ul>
-"""
-
     ICON = {"Machine": "⚙️", "Humain": "👤", "Deux": "🤝"}
-
-    # --- Sections par ingénieur
+    sections = []
     for resp in ingenieurs:
-        # Section header
-        html += "<hr style='margin:40px 0; border:none; border-top:1px solid #ccc;'/>\n"
-        html += f"<h2 id='{resp.replace(' ','_')}'>Actions de {resp}</h2>\n"
-
-        # Si l'ingénieur est en congé -> note et on passe à la suite
+        section = {"nom": resp, "id": resp.replace(" ", "_")}
         if resp in ingenieurs_en_conge:
-            html += "<p class='en-conge'>En congé — pas d'actions listées pour cette période.</p>\n"
+            section["conge"] = True
+            sections.append(section)
             continue
-
         grp = df[df["Prise en charge par"] == resp].copy()
         if grp.empty:
-            html += "<p class='en-conge'>Aucune action à afficher.</p>\n"
+            section["rows"] = []
+            sections.append(section)
             continue
-
-        # Tri Python (complémentaire au tri DataTables côté client)
         grp = grp.sort_values("__prio_num", ascending=tri_priorite_ascendant)
-
-        # Construction du tableau
-        html += "<table class='display'><thead><tr>\n"
-        for col in colonnes:
-            html += f"  <th>{col}</th>\n"
-        html += "</tr></thead><tbody>\n"
-
+        rows = []
         for _, row in grp.iterrows():
-            html += "<tr>"
+            row_vals = []
             for col in colonnes:
                 if col == nom_col_priorite_affiche:
                     val = int(row["__prio_num"])
                 elif col == "Type (Machine/Humain/Deux)":
-                    val = f"{ICON.get(row[col],'')} {row[col]}"
+                    val = f"{ICON.get(row[col], '')} {row[col]}"
                 else:
                     val = row[col]
-                html += f"<td>{val}</td>"
-            html += "</tr>\n"
+                row_vals.append(val)
+            rows.append(row_vals)
+        section["rows"] = rows
+        sections.append(section)
 
-        html += "</tbody></table>\n"
+    templates_dir = os.path.join(os.path.dirname(__file__), "templates")
+    env = Environment(loader=FileSystemLoader(templates_dir))
+    template = env.get_template("suivi.html.j2")
+    html = template.render(
+        today=today,
+        ingenieurs=ingenieurs,
+        colonnes=colonnes,
+        sections=sections,
+        page_length=page_length,
+        order_dir=order_dir,
+    )
 
-    html += "</body>\n</html>"
-
-    # --- Écriture du fichier
     with open(sortie_html, "w", encoding="utf-8") as f:
         f.write(html)
 
     return sortie_html
-
-
 # ======================
 # Exemple d'utilisation :
 # ======================

--- a/templates/suivi.html.j2
+++ b/templates/suivi.html.j2
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Suivi des actions – {{ today }}</title>
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css"/>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+<style>
+  body { font-family: Arial, sans-serif; margin:20px; }
+  h1, h2 { font-family: Arial, sans-serif; }
+  .toc ul {
+    display: flex; flex-wrap: wrap; gap: 8px;
+    padding: 0; margin: 0 0 30px 0;
+  }
+  .toc li { list-style: none; }
+  .toc a {
+    display: block;
+    padding: 6px 12px;
+    background: #f2f2f2;
+    border-radius: 20px;
+    text-decoration: none;
+    color: #0066cc;
+    transition: background 0.2s;
+  }
+  .toc a:hover { background: #ddeeff; }
+  table { table-layout: fixed; width:100%; border-collapse: collapse; margin-bottom:40px; }
+  th, td { padding:6px; border:1px solid #ddd; word-wrap: break-word; }
+  th { background:#e6e6e6; font-size:14px; text-align:left; }
+  td { font-size:12px; text-align:left; white-space: pre-wrap; }
+  .en-conge { color:#a00; font-style: italic; margin: 6px 0 16px 0; }
+</style>
+<script>
+$(document).ready(function() {
+    $('table.display').each(function() {
+      $(this).DataTable({
+        paging:      true,
+        pageLength:  {{ page_length }},
+        ordering:    true,
+        order:       [[3, '{{ order_dir }}']],
+        columnDefs:  [{ targets: 3, type: 'num' }],
+        fixedHeader: true,
+        scrollX:     true,
+        language:    { url: 'https://cdn.datatables.net/plug-ins/1.13.4/i18n/fr-FR.json' }
+      });
+    });
+});
+</script>
+</head>
+<body>
+<h1>Suivi des actions – {{ today }}</h1>
+
+<nav class="toc">
+  <ul>
+  {% for nom in ingenieurs %}
+    <li><a href="#{{ nom.replace(' ', '_') }}">{{ nom }}</a></li>
+  {% endfor %}
+  </ul>
+</nav>
+
+<p><strong>Conventions de lecture du tableau :</strong></p>
+<ul>
+  <li><strong>Actions “Machine”</strong> : Toute action de calcul machine dont les données sont prêtes doit être priorisée, car
+il s’agit de temps machine et non de temps humain.</li>
+</ul>
+
+{% for section in sections %}
+  <hr style='margin:40px 0; border:none; border-top:1px solid #ccc;'/>
+  <h2 id="{{ section.id }}">Actions de {{ section.nom }}</h2>
+  {% if section.conge %}
+    <p class="en-conge">En congé — pas d'actions listées pour cette période.</p>
+  {% elif not section.rows %}
+    <p class='en-conge'>Aucune action à afficher.</p>
+  {% else %}
+  <table class='display'>
+    <thead><tr>
+      {% for col in colonnes %}
+        <th>{{ col }}</th>
+      {% endfor %}
+    </tr></thead>
+    <tbody>
+      {% for row in section.rows %}
+        <tr>
+          {% for val in row %}
+            <td>{{ val }}</td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+{% endfor %}
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build HTML reports using a Jinja2 template instead of manual string concatenation
- add `templates/suivi.html.j2` and load it via `Environment` and `FileSystemLoader`

## Testing
- `python -m py_compile HTML_weekfollowup_generator.py`
- `pip install jinja2` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd9d80ec08322bf35b62a9a55108d